### PR TITLE
added option --outTmpDir

### DIFF
--- a/STAR-Fusion
+++ b/STAR-Fusion
@@ -38,6 +38,7 @@ my $MIN_SUM_FRAGS = 2;
 my $MAX_PROMISCUITY = 3;  # perhaps a poor choice of words, but still a best fit IMHO.
 my $genome_lib_dir;
 my $CPU = 4; 
+my $outTmpDir=undef;
 my $REQUIRE_LDAS = 1;
 
 my $BBMERGE_flag = 0;
@@ -85,6 +86,8 @@ my $usage = <<__EOUSAGE__;
 #    --denovo_reconstruct                  attempt to reconstruct fusion transcripts using de novo assembly (requires --FusionInspector)
 #
 #    --CPU <int>                           number of threads for running STAR (default: $CPU)
+#
+#    --outTmpDir <string>	           passed to STAR (very useful if local disks are faster than network disks)
 #
 #    --min_junction_reads <int>            minimum number of junction-spanning reads required. Default: $MIN_JUNCTION_READS
 #
@@ -175,6 +178,7 @@ my $EXAMINE_CODING_EFFECT = 0;
               'version' => \$REPORT_VERSION,
               
               'CPU=i' => \$CPU,
+              'outTmpDir=s' => \$outTmpDir,
 
               'STAR_use_shared_memory' => \$USE_SHARED_MEMORY,
               'STAR_MAX_MATE_DIST=i' => \$STAR_MAX_MATE_DIST,
@@ -487,6 +491,8 @@ sub missing_required_program_installed {
 ####
 sub run_STAR {
     my ($pipeliner, $left_fq_filename, $right_fq_filename, $output_prefix) = @_;
+
+    my $maybe_tmpdir= defined($outTmpDir)? " --outTmpDir $outTmpDir " : "";
     
     ## run STAR to align reads:
     my $cmd = "STAR --genomeDir $star_index_dir "
@@ -500,6 +506,7 @@ sub run_STAR {
         . " --chimSegmentReadGapMax 3 "
         . " --alignSJstitchMismatchNmax 5 -1 5 5 "  #which allows for up to 5 mismatches for non-canonical GC/AG, and AT/AC junctions, and any number of mismatches for canonical junctions (the default values 0 -1 0 0 replicate the old behavior (from AlexD)
         . " --runThreadN $CPU"
+        . $maybe_tmpdir
         . " --limitBAMsortRAM 31532137230 "
         . " --outSAMstrandField intronMotif "
         . " --outSAMunmapped Within "


### PR DESCRIPTION
... which is passed to STAR. This is useful in a large cluster
environment where local disk access (to e.g. /var/tmp) is much
faster than network disk access