### PR TITLE
support comma-separated fastq files

### DIFF
--- a/PerlLib/Fastq_reader.pm
+++ b/PerlLib/Fastq_reader.pm
@@ -20,6 +20,18 @@ sub new {
 	if (ref $fastqFile eq 'IO::Handle') {
 		$filehandle = $fastqFile;
 	}
+	elsif((! -e $fastqFile) && $fastqFile=~/,/){
+		my @files = split /,/, $fastqFile;
+		if ( $fastqFile =~ /\.gz$/ ) { 
+		    open $filehandle, "cat @files |gunzip -c |" or die "Error: Couldn't open compressed @files $!\n";
+		}
+		elsif ($fastqFile =~ /\.bz2$/) {
+		    open $filehandle, "cat @files |bunzip2 -c |" or die "Error: Couldn't open compressed @files $!\n";
+		}
+		else{
+		    open $filehandle, "cat @files |" or die "Error: Couldn't open @files\n";
+		}
+    	}
 	else {
 		if ( $fastqFile =~ /\.gz$/ ) {
 		    ## TODO:  need to handle the failure case, since not picked up here as I thought it would!!


### PR DESCRIPTION
With the tiny modification, multiple fastq files from the same sample can be processed correctly.