### PR TITLE
Pass along the RG line when using params file.

### DIFF
--- a/STAR-Fusion
+++ b/STAR-Fusion
@@ -983,6 +983,9 @@ sub run_STAR {
         if ($read_group_ids) {
             print $ofh "outSAMattrRGline $read_group_ids\n";
         }
+        elsif ($outSAMattrRGline) {
+            print $ofh "outSAMattrRGline $outSAMattrRGline\n";
+        }
         else {
             print $ofh "outSAMattrRGline ID:GRPundef\n";
         }


### PR DESCRIPTION
When the `--STAR_outSAMattrRGline` option was added in a4fda76387ff0aa6d1bed631400c6e1e505d115a, it only handled the case where a params file wasn't being used.  This lets the value from the option be passed along to STAR via the params file in the case where the input paths are long.