### PR TITLE
exit 0 for --help and --show_full_usage_info

### DIFF
--- a/STAR-Fusion
+++ b/STAR-Fusion
@@ -409,12 +409,14 @@ my $outSAMattrRGline = "";
 
 
 if ($SHOW_FULL_USAGE_INFO) {
-    die "$usage$extended_usage_info";
+    print "$usage$extended_usage_info";
+    exit(0);
 }
 
 
 if ($help_flag) {
-    die $usage;
+    print "$usage";
+    exit(0);
 }
 
 if ($REPORT_VERSION) {


### PR DESCRIPTION
STAR-Fusion --help and STAR-Fusion --show_full_usage_info  are valid arguments but exit with errors.
replace die with exit(0).


